### PR TITLE
feat: use mysql database for tasks

### DIFF
--- a/taskmanager-backend/package-lock.json
+++ b/taskmanager-backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^5.1.0",
+        "mysql2": "^3.10.1",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1"
       },
@@ -113,6 +114,15 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -327,6 +337,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -551,6 +570,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
       }
     },
     "node_modules/get-intrinsic": {
@@ -792,6 +820,12 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -823,6 +857,36 @@
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.2.tgz",
+      "integrity": "sha512-Nv9KddBcQSlQopmBHXSsZVY5xsdlZkdH/Iey0BlcBYggMd4two7cZnKOK9vmy3nY0O5RGH99z1PCeTpPqszUYg==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -892,6 +956,38 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mysql2": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.14.3.tgz",
+      "integrity": "sha512-fD6MLV8XJ1KiNFIF0bS7Msl8eZyhlTDCDl75ajU5SJtpdx9ZPEACulJcqJWr1Y8OYyxsFc4j3+nflpmhxCU5aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.1",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^5.2.1",
+        "lru.min": "^1.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
+      "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -1179,6 +1275,11 @@
         "node": ">= 18"
       }
     },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
+    },
     "node_modules/serve-static": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
@@ -1283,6 +1384,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/statuses": {

--- a/taskmanager-backend/package.json
+++ b/taskmanager-backend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "mysql2": "^3.10.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1"
   },

--- a/taskmanager-backend/src/server.js
+++ b/taskmanager-backend/src/server.js
@@ -3,8 +3,14 @@ const app = express();
 const swaggerUi = require('swagger-ui-express');
 const swaggerJsdoc = require('swagger-jsdoc');
 const cors = require('cors');
+const mysql = require('mysql2/promise');
 
-let tasks = []; // In-memory database
+const pool = mysql.createPool({
+  host: process.env.DB_HOST,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+});
 
 app.use(cors());
 app.use(express.json());
@@ -49,8 +55,13 @@ app.get('/', (req, res) => {
  *       200:
  *         description: List of tasks
  */
-app.get('/tasks', (req, res) => {
-  res.json(tasks);
+app.get('/tasks', async (req, res) => {
+  try {
+    const [rows] = await pool.query('SELECT * FROM tasks');
+    res.json(rows);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch tasks' });
+  }
 });
 
 /**
@@ -79,18 +90,25 @@ app.get('/tasks', (req, res) => {
  *       201:
  *         description: Task created
  */
-app.post('/tasks', (req, res) => {
-  const task = {
-    id: Date.now(),
-    title: req.body.title,
-    description: req.body.description,
-    dueDate: req.body.dueDate,
-    priority: req.body.priority,
-    completed: req.body.completed,
-    createdAt: new Date().toISOString()
-  };
-  tasks.push(task);
-  res.status(201).json(task);
+app.post('/tasks', async (req, res) => {
+  try {
+    const task = {
+      title: req.body.title,
+      description: req.body.description,
+      dueDate: req.body.dueDate,
+      priority: req.body.priority,
+      completed: req.body.completed,
+      createdAt: new Date().toISOString(),
+    };
+    const [result] = await pool.query(
+      'INSERT INTO tasks (title, description, dueDate, priority, completed, createdAt) VALUES (?, ?, ?, ?, ?, ?)',
+      [task.title, task.description, task.dueDate, task.priority, task.completed, task.createdAt]
+    );
+    task.id = result.insertId;
+    res.status(201).json(task);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to create task' });
+  }
 });
 
 /**
@@ -128,21 +146,32 @@ app.post('/tasks', (req, res) => {
  *       404:
  *         description: Task not found
  */
-app.put('/tasks/:id', (req, res) => {
+app.put('/tasks/:id', async (req, res) => {
   const taskId = Number(req.params.id);
-  const task = tasks.find(t => t.id === taskId);
+  try {
+    const [rows] = await pool.query('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'Task does not exist' });
+    }
 
-  if (!task) {
-    return res.status(404).json({ error: 'Task does not exist' });
+    const task = rows[0];
+    const updated = {
+      title: req.body.title ?? task.title,
+      description: req.body.description ?? task.description,
+      dueDate: req.body.dueDate ?? task.dueDate,
+      priority: req.body.priority ?? task.priority,
+      completed: req.body.completed !== undefined ? req.body.completed : task.completed,
+    };
+
+    await pool.query(
+      'UPDATE tasks SET title = ?, description = ?, dueDate = ?, priority = ?, completed = ? WHERE id = ?',
+      [updated.title, updated.description, updated.dueDate, updated.priority, updated.completed, taskId]
+    );
+
+    res.json({ id: taskId, createdAt: task.createdAt, ...updated });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to update task' });
   }
-
-  if (req.body.title !== undefined) task.title = req.body.title;
-  if (req.body.description !== undefined) task.description = req.body.description;
-  if (req.body.dueDate !== undefined) task.dueDate = req.body.dueDate;
-  if (req.body.priority !== undefined) task.priority = req.body.priority;
-  if (req.body.completed !== undefined) task.completed = !!req.body.completed;
-
-  res.json(task);
 });
 
 /**
@@ -163,16 +192,17 @@ app.put('/tasks/:id', (req, res) => {
  *       404:
  *         description: Task not found
  */
-app.delete('/tasks/:id', (req, res) => {
+app.delete('/tasks/:id', async (req, res) => {
   const taskId = Number(req.params.id);
-  const index = tasks.findIndex(t => t.id === taskId);
-
-  if (index === -1) {
-    return res.status(404).json({ error: 'Task does not exist' });
+  try {
+    const [result] = await pool.query('DELETE FROM tasks WHERE id = ?', [taskId]);
+    if (result.affectedRows === 0) {
+      return res.status(404).json({ error: 'Task does not exist' });
+    }
+    res.status(204).send();
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to delete task' });
   }
-
-  tasks.splice(index, 1);
-  res.status(204).send();
 });
 
 const PORT = 3000;


### PR DESCRIPTION
## Summary
- replace in-memory task storage with MySQL database using mysql2
- add mysql2 dependency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68937bb81d38832c9fa801b859a0c7f4